### PR TITLE
added closing bracket if cplusplus defined

### DIFF
--- a/XilinxProcessorIPLib/drivers/sysmonpsu/src/xsysmonpsu.h
+++ b/XilinxProcessorIPLib/drivers/sysmonpsu/src/xsysmonpsu.h
@@ -650,5 +650,8 @@ s32 XSysMonPsu_SelfTest(XSysMonPsu *InstancePtr);
 /* Functions in xsysmonpsu_sinit.c */
 XSysMonPsu_Config *XSysMonPsu_LookupConfig(u16 DeviceId);
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* XSYSMONPSU_H_ */


### PR DESCRIPTION
Closing bracket was missed and is added:
#ifdef __cplusplus
}
#endif